### PR TITLE
fix(tools): validate host ~/.gitconfig before compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ ENABLE_SERVICES="nginx,php-fpm,workspace,postgres,mysql,redis,rabbitmq,minio"
 DEPENDENCY_PHP_EXTENSIONS="gd,imagick,redis,xdebug,opcache"
 ```
 
+### Git configuration (host)
+
+The `workspace` service bind-mounts your host `~/.gitconfig` (see `docker-compose.yml`). That path must be a **regular file** (for example create it with `touch ~/.gitconfig` or set `user.name` / `user.email` with `git config --global`) **before** the first `docker compose up` that starts `workspace` if you skip `make setup`. If the file is missing, Docker can create a **directory** at the same path, which breaks Git. `make setup` checks this before continuing (including when it restarts containers at the end).
+
 ### Composer Authentication
 
 For private repositories, configure `workspace/auth.json`:

--- a/tools/lib/core/utils.sh
+++ b/tools/lib/core/utils.sh
@@ -158,6 +158,31 @@ version_compare() {
 }
 
 # =============================================================================
+# HOST GIT CONFIG (user-facing; validate_host_gitconfig in validation.sh is silent)
+# =============================================================================
+
+# Prints messages for a failed validate_host_gitconfig; reads HOST_GITCONFIG_ERROR
+print_host_gitconfig_error() {
+    local path
+    path="${HOME}/.gitconfig"
+
+    case "${HOST_GITCONFIG_ERROR:-}" in
+        directory)
+            print_error "Invalid Git config: $path is a directory, not a file"
+            print_tip "If this was missing on first 'docker compose up', Docker can create a directory. If the directory is empty, run:  rmdir \"$path\"  then:  touch \"$path\""
+            ;;
+        missing)
+            print_error "Missing Git config file: $path"
+            print_tip "The workspace service expects a regular file at that path, e.g.:  touch \"$path\""
+            print_tip "or:  git config --global user.name \"...\"  and  git config --global user.email \"...\""
+            ;;
+        not_regular)
+            print_error "Invalid Git config: $path exists but is not a regular file"
+            ;;
+    esac
+}
+
+# =============================================================================
 # ARGUMENT PARSING
 # =============================================================================
 

--- a/tools/lib/core/validation.sh
+++ b/tools/lib/core/validation.sh
@@ -124,3 +124,39 @@ validate_template_syntax() {
 
     return "$EXIT_SUCCESS"
 }
+
+# =============================================================================
+# HOST GIT CONFIG (for docker-compose bind mount of ~/.gitconfig)
+# =============================================================================
+# The workspace service mounts the host's ~/.gitconfig. If the path is missing
+# on first "docker compose up", Docker can create a directory in its place, which
+# breaks Git. Call this before any compose "up" that includes the workspace.
+#
+# On failure, sets HOST_GITCONFIG_ERROR to: directory | missing | not_regular
+# (read by print_host_gitconfig_error in utils.sh)
+
+validate_host_gitconfig() {
+    local path
+    path="${HOME}/.gitconfig"
+    HOST_GITCONFIG_ERROR=""
+
+    if [ -d "$path" ]; then
+        # shellcheck disable=SC2034
+        HOST_GITCONFIG_ERROR="directory"
+        return "$EXIT_INVALID_CONFIG"
+    fi
+
+    if [ ! -e "$path" ]; then
+        # shellcheck disable=SC2034
+        HOST_GITCONFIG_ERROR="missing"
+        return "$EXIT_INVALID_CONFIG"
+    fi
+
+    if [ ! -f "$path" ]; then
+        # shellcheck disable=SC2034
+        HOST_GITCONFIG_ERROR="not_regular"
+        return "$EXIT_INVALID_CONFIG"
+    fi
+
+    return "$EXIT_SUCCESS"
+}

--- a/tools/lib/services/containers.sh
+++ b/tools/lib/services/containers.sh
@@ -19,6 +19,7 @@ CONTAINERS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 source "$CONTAINERS_SCRIPT_DIR/../core/utils.sh"
 source "$CONTAINERS_SCRIPT_DIR/../core/config.sh"
+source "$CONTAINERS_SCRIPT_DIR/../core/validation.sh"
 source "$CONTAINERS_SCRIPT_DIR/../core/docker.sh"
 
 # =============================================================================
@@ -32,6 +33,14 @@ manage_containers() {
     if ! ensure_docker_available; then
         print_error "Docker is not available"
         return "$EXIT_MISSING_DEPENDENCY"
+    fi
+
+    # start/restart run compose with workspace; bind mount needs a valid file (see validation.sh)
+    if [[ "$action" == "start" || "$action" == "restart" ]]; then
+        if ! validate_host_gitconfig; then
+            print_host_gitconfig_error
+            return "$EXIT_INVALID_CONFIG"
+        fi
     fi
 
     # Load environment variables

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -53,7 +53,7 @@ USAGE:
     DESCRIPTION:
     Complete setup of DockerKit development environment including:
     • System dependencies check (with installation instructions)
-    • Git configuration generation
+    • Host Git config check (~/.gitconfig must be a regular file for the workspace)
     • Project detection and analysis (.localhost domains only)
     • Network aliases generation for Docker Compose
     • Hosts file management
@@ -67,13 +67,14 @@ EXAMPLES:
     ./setup.sh                  # Full environment setup
 
     PROCESS:
-    1. Check system dependencies
-    2. Scan for .localhost projects in parent directory
-    3. Generate Docker Compose network aliases
-    4. Set up hosts file entries for discovered projects
-    5. Generate SSL certificates for HTTPS support
-    6. Generate nginx configurations based on project types
-    7. Validate all generated configurations
+    1. Validate host Git config (~/.gitconfig)
+    2. Check system dependencies
+    3. Scan for .localhost projects in parent directory
+    4. Generate Docker Compose network aliases
+    5. Set up hosts file entries for discovered projects
+    6. Generate SSL certificates for HTTPS support
+    7. Generate nginx configurations based on project types
+    8. Validate all generated configurations
 
 EOF
 }
@@ -81,6 +82,12 @@ EOF
 # Main setup function
 main() {
     print_header "DOCKERKIT ENVIRONMENT SETUP"
+
+    if ! validate_host_gitconfig; then
+        print_host_gitconfig_error
+        print_tip "Fix the issue above before continuing"
+        exit "$EXIT_INVALID_CONFIG"
+    fi
 
     # Step 1: Install required tools (essential for DockerKit functionality)
     print_section "Installing Required Tools"


### PR DESCRIPTION
## Summary

The `workspace` service bind-mounts `${HOME}/.gitconfig`. If that path is missing on first `docker compose up`, Docker can create a **directory** with that name, which breaks Git. This change fails fast with a clear message when `~/.gitconfig` is missing, a directory, or not a regular file.

## Changes

- Add `validate_host_gitconfig` in `tools/lib/core/validation.sh` (sets `HOST_GITCONFIG_ERROR` for callers; no UI in this module).
- Add `print_host_gitconfig_error` in `tools/lib/core/utils.sh` for user-facing messages.
- Run validation at the start of `make setup` / `setup.sh`.
- Run validation in `manage_containers` for **`start` and `restart` only** (not `stop`), before compose.
- Do **not** add checks to `make start` / `make restart` in the Makefile (assumption: `make setup` was run or the file already exists).
- Update README with a short “Git configuration (host)” subsection; align `setup.sh` help with the new step.