### PR TITLE
feat(docker): add prometheus and grafana monitoring services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ DEFAULT_PASSWORD="${PROJECT_NAME}"
 # Service activation - specify which services to start
 # Available services: nginx php-fpm workspace postgres mysql mongo redis
 #                    rabbitmq elasticsearch elasticvue minio mailpit portainer
+#                    prometheus grafana
 
 ENABLE_SERVICES="nginx php-fpm workspace postgres mysql redis rabbitmq elasticsearch elasticvue minio mailpit"
 
@@ -206,3 +207,22 @@ MAILPIT_VERSION=latest
 # Repository: https://github.com/portainer/portainer
 # Available tags: https://hub.docker.com/r/portainer/portainer-ce/tags
 PORTAINER_VERSION=lts
+
+# =============================================================================
+# Prometheus Configuration (Metrics Collection)
+# =============================================================================
+# Repository: https://github.com/prometheus/prometheus
+# Available tags: https://hub.docker.com/r/prom/prometheus/tags
+PROMETHEUS_VERSION=latest
+PROMETHEUS_PORT=9090
+PROMETHEUS_RETENTION_TIME=30d
+
+# =============================================================================
+# Grafana Configuration (Metrics Visualization)
+# =============================================================================
+# Repository: https://github.com/grafana/grafana
+# Available tags: https://hub.docker.com/r/grafana/grafana/tags
+GRAFANA_VERSION=latest
+GRAFANA_PORT=3100
+GRAFANA_ADMIN_USER="${DEFAULT_USER}"
+GRAFANA_ADMIN_PASSWORD="${DEFAULT_PASSWORD}"

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,12 @@
 # Auto-generated network aliases
 docker-compose.aliases.yml
 
+# Prometheus scrape configuration (contains project-specific targets)
+/prometheus/prometheus.yml
+
+# Grafana dashboards (distributed out-of-band, not tracked by git)
+/grafana/dashboards/*.json
+
 # Ignore dump files but not directories
 dumps/mysql/*
 dumps/postgres/*

--- a/README.md
+++ b/README.md
@@ -252,13 +252,17 @@ tree            # tree -I vendor -C
 
 Access management interfaces for development services:
 
-| Service           | URL                      | Credentials           | Purpose           |
-|-------------------|--------------------------|-----------------------|-------------------|
-| **Mailpit**       | <http://localhost:8125>  | -                     | Email testing     |
-| **MinIO Console** | <http://localhost:9001>  | dockerkit / dockerkit | File storage      |
-| **RabbitMQ**      | <http://localhost:15672> | dockerkit / dockerkit | Message queues    |
-| **Elasticvue**    | <http://localhost:9210>  | -                     | Elasticsearch UI  |
-| **Portainer**     | <http://localhost:9010>  | Setup on first visit  | Docker management |
+| Service           | URL                      | Credentials           | Purpose             |
+|-------------------|--------------------------|-----------------------|---------------------|
+| **Mailpit**       | <http://localhost:8125>  | -                     | Email testing       |
+| **MinIO Console** | <http://localhost:9001>  | dockerkit / dockerkit | File storage        |
+| **RabbitMQ**      | <http://localhost:15672> | dockerkit / dockerkit | Message queues      |
+| **Elasticvue**    | <http://localhost:9210>  | -                     | Elasticsearch UI    |
+| **Portainer**     | <http://localhost:9010>  | Setup on first visit  | Docker management   |
+| **Prometheus**    | <http://localhost:9090>  | -                     | Metrics collection  |
+| **Grafana**       | <http://localhost:3100>  | dockerkit / dockerkit | Metrics dashboards  |
+
+> Prometheus and Grafana are optional services. Add `prometheus grafana` to `ENABLE_SERVICES` in `.env` to start them.
 
 ## Development Tools
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -394,6 +394,60 @@ services:
     networks:
       - web
 
+  ### Prometheus ###########################################
+  prometheus:
+    image: prom/prometheus:${PROMETHEUS_VERSION}
+    restart: unless-stopped
+    ports:
+      - "${PROMETHEUS_PORT}:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=${PROMETHEUS_RETENTION_TIME}'
+      - '--web.enable-lifecycle'
+    environment:
+      - TZ
+    healthcheck:
+      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9090/-/healthy" ]
+      interval: ${HEALTH_CHECK_INTERVAL}
+      timeout: ${HEALTH_CHECK_TIMEOUT}
+      retries: ${HEALTH_CHECK_RETRIES}
+      start_period: 30s
+    networks:
+      - web
+      - backend
+
+  ### Grafana ##############################################
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION}
+    restart: unless-stopped
+    ports:
+      - "${GRAFANA_PORT}:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+      - TZ
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/health" ]
+      interval: ${HEALTH_CHECK_INTERVAL}
+      timeout: ${HEALTH_CHECK_TIMEOUT}
+      retries: ${HEALTH_CHECK_RETRIES}
+      start_period: 30s
+    networks:
+      - web
+
   ### Portainer ############################################
   portainer:
     image: portainer/portainer-ce:${PORTAINER_VERSION}
@@ -431,3 +485,5 @@ volumes:
   minio_config:
   mailpit_data:
   portainer_data:
+  prometheus_data:
+  grafana_data:

--- a/grafana/provisioning/dashboards/provider.yml
+++ b/grafana/provisioning/dashboards/provider.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+providers:
+  - name: Default
+    type: file
+    disableDeletion: true
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/grafana/provisioning/datasources/prometheus.yml
+++ b/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/prometheus/prometheus.yml.example
+++ b/prometheus/prometheus.yml.example
@@ -1,0 +1,41 @@
+# =============================================================================
+# Prometheus Scrape Configuration
+# =============================================================================
+# Copy this file to prometheus.yml and configure your scrape targets.
+#
+# DockerKit assigns each .localhost project as a network alias of the nginx
+# container (see docker-compose.aliases.yml). Prometheus runs on the same Docker
+# network, so it can resolve project domains directly. The Host header is set
+# automatically from the target address, and nginx routes the request to the
+# correct PHP-FPM backend.
+#
+# Scrape target pattern for a .localhost project:
+#
+#   - job_name: '<service-name>'
+#     metrics_path: '/metrics'
+#     static_configs:
+#       - targets: ['<project>.localhost:80']
+# =============================================================================
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  # ---------------------------------------------------------------------------
+  # Prometheus self-monitoring
+  # ---------------------------------------------------------------------------
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  # ---------------------------------------------------------------------------
+  # Your microservices
+  # ---------------------------------------------------------------------------
+  # Add one job per service that exposes a /metrics endpoint.
+  # Replace 'myapp' and 'myapp.localhost' with your actual service details.
+  #
+  # - job_name: 'myapp'
+  #   metrics_path: '/metrics'
+  #   static_configs:
+  #     - targets: ['myapp.localhost:80']

--- a/tools/lib/core/files.sh
+++ b/tools/lib/core/files.sh
@@ -21,6 +21,7 @@ SETUP_FILES=(
     "php-fpm/www.conf.example:php-fpm/www.conf"
     "php-fpm/php.ini.example:php-fpm/php.ini"
     "workspace/php.ini.example:workspace/php.ini"
+    "prometheus/prometheus.yml.example:prometheus/prometheus.yml"
 )
 
 # Create file from example if it doesn't exist

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -179,6 +179,7 @@ ask_container_restart() {
             containers_restarted=true
             # Show available sites after successful restart
             show_available_sites "${projects[@]}"
+            show_available_panels
         else
             print_error "Failed to restart containers"
             exit "$EXIT_GENERAL_ERROR"
@@ -187,6 +188,41 @@ ask_container_restart() {
 
     # Always show next steps, but conditionally show restart instruction
     show_next_steps "$containers_restarted"
+}
+
+# Show available web UI panels for enabled services
+show_available_panels() {
+    local services="${ENABLE_SERVICES:-}"
+    [ -z "$services" ] && return 0
+
+    # service|label|port (port resolved from .env, with fallback)
+    local panel_map=(
+        "rabbitmq|RabbitMQ|${RABBITMQ_MANAGEMENT_HTTP_HOST_PORT:-15672}"
+        "elasticvue|Elasticvue|${ELASTICVUE_HTTP_PORT:-9210}"
+        "minio|MinIO Console|${MINIO_CONSOLE_PORT:-9001}"
+        "mailpit|Mailpit|${MAILPIT_HTTP_PORT:-8125}"
+        "portainer|Portainer|${PORTAINER_PORT:-9010}"
+        "prometheus|Prometheus|${PROMETHEUS_PORT:-9090}"
+        "grafana|Grafana|${GRAFANA_PORT:-3100}"
+    )
+
+    local output=()
+    for entry in "${panel_map[@]}"; do
+        local service="${entry%%|*}"
+        local rest="${entry#*|}"
+        local label="${rest%%|*}"
+        local port="${rest#*|}"
+        if echo "$services" | grep -qw "$service"; then
+            output+=("$(printf '%-20s %s' "$label" "http://localhost:${port}")")
+        fi
+    done
+
+    [ ${#output[@]} -eq 0 ] && return 0
+
+    print_section "Available panels"
+    for line in "${output[@]}"; do
+        print_success "$line"
+    done
 }
 
 # Show available sites


### PR DESCRIPTION
- Add prometheus and grafana as optional services in docker-compose.yml
- Add prometheus/prometheus.yml.example with .localhost scrape pattern
- Add grafana provisioning for datasource and dashboard provider
- Extend SETUP_FILES to auto-create prometheus.yml on make setup
- Add show_available_panels to setup summary output
- Update .env.example, .gitignore, and README