### PR TITLE
feat(postgres): use versioned PGDATA so 13 and 18 share one volume mount

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,6 +118,9 @@ NGINX_VERSION=1.28-alpine
 # =============================================================================
 # Repository: https://github.com/postgres/postgres
 # Available tags: https://hub.docker.com/_/postgres/tags
+# 13 and 18 share the same volume layout (MAJOR/docker). Changing the major
+# version requires recreating postgres_data or dump/restore. In-place upgrade
+# is not supported.
 POSTGRES_VERSION=17
 POSTGRES_DB=default
 POSTGRES_USER="${DEFAULT_USER}"

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -40,3 +40,10 @@ jobs:
           dockerfile: php-fpm/Dockerfile
           format: gcc
           failure-threshold: error
+
+      - name: Run Hadolint on postgres/Dockerfile
+        uses: hadolint/hadolint-action@v3.4.0
+        with:
+          dockerfile: postgres/Dockerfile
+          format: gcc
+          failure-threshold: error

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -2,7 +2,9 @@ ignored:
   - DL3003  # Use WORKDIR to switch to a directory - subshell (cd && cmd) is acceptable pattern
   - DL3008  # Pin versions in apt get install - ignored for dev environment flexibility
   - DL3016  # Pin versions in npm - ignored for dev environment flexibility
+  - DL3025  # HEALTHCHECK CMD shell form - matches existing workspace/php-fpm pattern
   - DL3059  # Multiple consecutive RUN instructions - acceptable for readability
+  - DL3066  # USER ${APP_UID}:${APP_GID} is numeric at build time via ARG
   - SC2015  # A && B || C is not if-then-else - known shell pattern
   - SC2086  # Double quote to prevent globbing - word splitting needed for package lists
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ ENABLE_SERVICES="nginx,php-fpm,workspace,postgres,mysql,redis,rabbitmq,minio"
 
 # Customize PHP extensions
 DEPENDENCY_PHP_EXTENSIONS="gd,imagick,redis,xdebug,opcache"
+
+# PostgreSQL major (13 and 18 both work). Recreate postgres_data when changing it.
+POSTGRES_VERSION=17
 ```
 
 ### Git configuration (host)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,7 +154,10 @@ services:
 
   ### PostgreSQL ###########################################
   postgres:
-    image: postgres:${POSTGRES_VERSION}
+    build:
+      context: ./postgres
+      args:
+        - POSTGRES_VERSION
     restart: unless-stopped
     ports:
       - "${POSTGRES_PORT}:5432"
@@ -164,7 +167,7 @@ services:
       - POSTGRES_PASSWORD
       - TZ
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
       - ${POSTGRES_ENTRYPOINT_INITDB}:/docker-entrypoint-initdb.d
       - ./postgres/postgresql.conf:/etc/postgresql/postgresql.conf:ro
     command: ["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"]

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1.4
+# check=error=true
+
+ARG POSTGRES_VERSION=17
+
+FROM postgres:${POSTGRES_VERSION}
+
+# Official 18+ images store data at /var/lib/postgresql/MAJOR/docker and declare
+# VOLUME /var/lib/postgresql. 13-17 still use /var/lib/postgresql/data as VOLUME,
+# so a parent-directory mount does not persist. Pin the 18+ layout for every major
+# so compose can always mount postgres_data at /var/lib/postgresql.
+ENV PGDATA=/var/lib/postgresql/${PG_MAJOR}/docker


### PR DESCRIPTION
Official 18 images store data under MAJOR/docker. Pin that layout for every major so compose can always mount postgres_data at /var/lib/postgresql. Changing the major still needs a new volume.